### PR TITLE
[Feat] 사용자의 활력 징후를 가져오는 REST API 생성

### DIFF
--- a/packages/server/routes/user/user.js
+++ b/packages/server/routes/user/user.js
@@ -6,6 +6,7 @@ router.get('/users/:uid', userMid.readUser);
 router.get('/users/:uid/appointments', userMid.readUserAppointments);
 router.get('/users/:uid/diagnoses', userMid.readUserDiagnoses);
 router.get('/users/:uid/medecines', userMid.readUserMedecines);
+router.get('/users/:uid/vital-signs', userMid.readUserVitalSigns);
 router.post('/users', userMid.createUser);
 router.patch('/users/:uid', userMid.updateUser);
 

--- a/packages/server/utils/classifyVitalSigns.js
+++ b/packages/server/utils/classifyVitalSigns.js
@@ -1,0 +1,21 @@
+module.exports = vitalSignsFromDB => {
+  const vitalSigns = {
+    heartRate: [],
+    temperature: [],
+  };
+
+  for (let i = 0; i < vitalSignsFromDB.length; i += 1) {
+    switch (vitalSignsFromDB[i].type) {
+      case 'heartRate':
+        vitalSigns.heartRate.push(vitalSignsFromDB[i]);
+        break;
+      case 'temperature':
+        vitalSigns.temperature.push(vitalSignsFromDB[i]);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return vitalSigns;
+};


### PR DESCRIPTION
## PR 타입
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- get요청을 통해 사용자의 활력 징후를 가져온다.
- type(temperature, heartRate)에 따라 관련 값들을 모두 가져온다.
- type이 없으면 모든 type 값들을 가져온다.
- 시간은 정렬하여 가져온다.

관련 이슈: #247 


## 테스트 결과
![image](https://github.com/hwna00/2023ESWContest_webOS_3015/assets/66236249/c8609ae2-fd27-4565-abaf-02ecf8c60ecf)


## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
